### PR TITLE
Push template cleanup commit to correct branch

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -69,4 +69,5 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
+          branch: main
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`ad-m/github-push-action` defaults to pushing `HEAD` to `master`, but we want it to go to `main` now